### PR TITLE
Implement GetDeploymentByName(string)

### DIFF
--- a/deployment.go
+++ b/deployment.go
@@ -165,6 +165,22 @@ func (c *Client) GetDeployment(deploymentid string) (*Deployment, []error) {
 	return &deployment, nil
 }
 
+//GetDeploymentByName returns a deployment of a given name
+func (c *Client) GetDeploymentByName(deploymentName string) (*Deployment, []error) {
+	deployments, errs := c.GetDeployments()
+	if errs != nil {
+		return nil, errs
+	}
+
+	for _, deployment := range *deployments {
+		if deployment.Name == deploymentName {
+			return &deployment, nil
+		}
+	}
+
+	return nil, []error{fmt.Errorf("deployment not found: %s", deploymentName)}
+}
+
 //DeprovisionDeploymentJSON performs the call
 func (c *Client) DeprovisionDeploymentJSON(deploymentID string) (string, []error) {
 


### PR DESCRIPTION
This is a helper function which acts like `GetDeployment(string)` but takes
a `Deployment.Name` instead of `Deployment.ID`. It is useful for us because
we don't keep track of the deployment ID and instead set the Name to a UUID
that we already know.

This code has been extracted from our Cloud Foundry broker because we feel
like it may be useful to other people and belongs in the library:

- https://github.com/alphagov/paas-compose-broker/blob/da7c995a49fe1d33a4c8062164c1bd147ff2d538/broker/utils.go#L13-L26

In the longer term it would be preferable if the API could provide a filter
for getting deployments so that you didn't need to fetch all and then
iterate over them. I've raised a support ticket (#384655082).