### PR TITLE
Implement GetClusterByName(string)

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -16,6 +16,7 @@ package composeapi
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 )
 
@@ -57,4 +58,20 @@ func (c *Client) GetClusters() (*[]Cluster, []error) {
 	clusters := clustersResponse.Embedded.Clusters
 
 	return &clusters, nil
+}
+
+//GetClusterByName returns a cluster of a given name
+func (c *Client) GetClusterByName(clusterName string) (*Cluster, []error) {
+	clusters, errs := c.GetClusters()
+	if errs != nil {
+		return nil, errs
+	}
+
+	for _, cluster := range *clusters {
+		if cluster.Name == clusterName {
+			return &cluster, nil
+		}
+	}
+
+	return nil, []error{fmt.Errorf("cluster not found: %s", clusterName)}
 }


### PR DESCRIPTION
Similarly to https://github.com/compose/gocomposeapi/pull/6 this implements a helper function that returns a cluster based on a name.
It's useful as all calls to enterprise accounts must contain cluster ID.
The only way to do it right now is to do end software based filtering from the output of GetClusters().

This commit moves the functionality to the API library but it would be good to
have such thing in the API to save bandwidth on both sides.