### PR TITLE
Support cluster link

### DIFF
--- a/deployment.go
+++ b/deployment.go
@@ -33,9 +33,16 @@ type Deployment struct {
 	Connection          ConnectionStrings `json:"connection_strings,omitempty"`
 	Notes               string            `json:"notes,omitempty"`
 	CustomerBillingCode string            `json:"customer_billing_code,omitempty"`
-	Links               struct {
-		ComposeWebUILink Link `json:"compose_web_ui"`
-	} `json:"_links"`
+	Links               Links             `json:"_links"`
+}
+
+// Links structure, part of the Deployment struct
+type Links struct {
+	ComposeWebUILink Link `json:"compose_web_ui"`
+	ScalingsLink     Link `json:"scalings"`
+	BackupsLink      Link `json:"backups"`
+	AlertsLink       Link `json:"alerts"`
+	ClusterLink      Link `json:"cluster"`
 }
 
 // ConnectionStrings structure, part of the Deployment struct


### PR DESCRIPTION
To be able to check if a deployment belongs to a specific cluster one needs
to know the underlying cluster ID. The only place that
cluster ID is advertised in the deployment response is the cluster link.

https://apidocs.compose.com/v1.0/reference#2016-07-get-deployments-id

This commit adds support for cluster link to the `Deployment` struct so
cluster ID can be extracted.