### PR TITLE
Implement GetCluster method

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -60,6 +60,25 @@ func (c *Client) GetClusters() (*[]Cluster, []error) {
 	return &clusters, nil
 }
 
+//GetClusterJSON returns raw cluster
+func (c *Client) GetClusterJSON(clusterid string) (string, []error) {
+	return c.getJSON("clusters/" + clusterid)
+}
+
+//GetDeployment returns deployment structure
+func (c *Client) GetCluster(clusterid string) (*Cluster, []error) {
+	body, errs := c.GetClusterJSON(clusterid)
+
+	if errs != nil {
+		return nil, errs
+	}
+
+	cluster := Cluster{}
+	json.Unmarshal([]byte(body), &cluster)
+
+	return &cluster, nil
+}
+
 //GetClusterByName returns a cluster of a given name
 func (c *Client) GetClusterByName(clusterName string) (*Cluster, []error) {
 	clusters, errs := c.GetClusters()


### PR DESCRIPTION
This PR implements support for [get cluster by id API endpoint](https://apidocs.compose.com/v1.0/reference#2016-07-get-clusters-id).

> "This endpoint returns a single cluster associated with the cluster id used in the path parameters. It returns the same information as the /2016-07/clusters endpoint, but for a single cluster"

So  now we can get cluser by ID! 🎉 