### PR TITLE
Add support for the PATCH /deployments/:deployment_id/versions API call

### DIFF
--- a/database.go
+++ b/database.go
@@ -16,6 +16,9 @@ package composeapi
 
 import (
 	"encoding/json"
+	"fmt"
+
+	"github.com/parnurzeal/gorequest"
 )
 
 //Version structure
@@ -44,6 +47,44 @@ func (c *Client) GetVersionsForDeployment(deploymentid string) (*[]VersionTransi
 	versionTransitions := versionsResponse.Embedded.VersionTransitions
 
 	return &versionTransitions, nil
+}
+
+func (c *Client) UpdateVersionJSON(deploymentID string, version string) (string, []error) {
+	patchParams := patchDeploymentVersionParams{
+		Deployment: deploymentVersion{Version: version},
+	}
+
+	response, body, errs := gorequest.New().
+		Patch(apibase+"deployments/"+deploymentID+"/versions").
+		Set("Authorization", "Bearer "+c.apiToken).
+		Set("Content-type", "application/json; charset=utf-8").
+		Send(patchParams).
+		End()
+
+	if response.StatusCode != 200 { // Expect OK on success - assume error on anything else
+		myErrors := Errors{}
+		err := json.Unmarshal([]byte(body), &myErrors)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("Unable to parse error - status code %d - body %s",
+				response.StatusCode, body))
+		} else {
+			errs = append(errs, fmt.Errorf("%v", myErrors.Error))
+		}
+	}
+
+	return body, errs
+}
+
+func (c *Client) UpdateVersion(deploymentID, version string) (*Recipe, []error) {
+	body, errs := c.UpgradeVersionForDeploymentJSON(deploymentID, version)
+	if errs != nil {
+		return nil, errs
+	}
+
+	recipe := Recipe{}
+	json.Unmarshal([]byte(body), &recipe)
+
+	return &recipe, nil
 }
 
 //Database structure

--- a/deployment.go
+++ b/deployment.go
@@ -33,6 +33,7 @@ type Deployment struct {
 	Connection          ConnectionStrings `json:"connection_strings,omitempty"`
 	Notes               string            `json:"notes,omitempty"`
 	CustomerBillingCode string            `json:"customer_billing_code,omitempty"`
+	Version             string            `json:"version,omitempty"`
 	Links               Links             `json:"_links"`
 }
 
@@ -112,6 +113,14 @@ type versionsResponse struct {
 	Embedded struct {
 		VersionTransitions []VersionTransition `json:"transitions"`
 	} `json:"_embedded"`
+}
+
+type patchDeploymentVersionParams struct {
+	Deployment deploymentVersion `json:"deployment"`
+}
+
+type deploymentVersion struct {
+	Version string `json:"version"`
 }
 
 //CreateDeploymentJSON performs the call


### PR DESCRIPTION
Exposing the Version field in the GetDeployment response struct, and then adding this PATCH API command allows users of this library to programmatically upgrade their databases. I'm not entirely certain my naming of these methods matches the rest of the repo, but I think "UpgradeVersion" is a better description of the function's purpose than "PatchVersion".

That said I have no problem changing the name if you disagree.

I tested my PR using the following gist: https://gist.github.com/benjdewan/4f9eb2a6c572c44666b2f13cf4f5b2f4

