### PR TITLE
Creating teams and team roles returns an HTTP 201 Created

### DIFF
--- a/team_roles.go
+++ b/team_roles.go
@@ -52,7 +52,7 @@ func (c *Client) CreateTeamRoleJSON(deploymentID string, params TeamRoleParams) 
 		Send(updateTeamRole{TeamRole: params}).
 		End()
 
-	if response.StatusCode != 200 {
+	if response.StatusCode != 201 {
 		myErrors := Errors{}
 		err := json.Unmarshal([]byte(body), &myErrors)
 		if err != nil {

--- a/teams.go
+++ b/teams.go
@@ -61,7 +61,7 @@ func (c *Client) CreateTeamJSON(params TeamParams) (string, []error) {
 		Send(teamParams).
 		End()
 
-	if response.StatusCode != 200 { // Expect OK on success - assume error on anything else
+	if response.StatusCode != 201 { // Expect Created on success - assume error on anything else
 		myErrors := Errors{}
 		err := json.Unmarshal([]byte(body), &myErrors)
 		if err != nil {


### PR DESCRIPTION
This was what was in the documentation, but in practice those methods were returning HTTP 200 OK messages until a recent API update