### PR TITLE
Add support for the new cluster tag API methods

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -32,6 +32,7 @@ type Cluster struct {
 	AccountSlug string    `json:"account_slug"`
 	CreatedAt   time.Time `json:"created_at"`
 	Subdomain   string    `json:"subdomain"`
+	Tags        []string  `json:tags"`
 }
 
 type clusterResponse struct {

--- a/deployment.go
+++ b/deployment.go
@@ -88,17 +88,18 @@ type PatchDeploymentParams struct {
 
 // DeploymentParams core parameters for a new deployment
 type DeploymentParams struct {
-	Name                string `json:"name"`
-	AccountID           string `json:"account_id"`
-	ClusterID           string `json:"cluster_id,omitempty"`
-	Datacenter          string `json:"datacenter,omitempty"`
-	DatabaseType        string `json:"type"`
-	Version             string `json:"version,omitempty"`
-	Units               int    `json:"units,omitempty"`
-	SSL                 bool   `json:"ssl,omitempty"`
-	WiredTiger          bool   `json:"wired_tiger,omitempty"`
-	Notes               string `json:"notes,omitempty"`
-	CustomerBillingCode string `json:"customer_billing_code,omitempty"`
+	Name                string   `json:"name"`
+	AccountID           string   `json:"account_id"`
+	ClusterID           string   `json:"cluster_id,omitempty"`
+	Datacenter          string   `json:"datacenter,omitempty"`
+	ProvisioningTags    []string `json:"provisioning_tags,omitempty"`
+	DatabaseType        string   `json:"type"`
+	Version             string   `json:"version,omitempty"`
+	Units               int      `json:"units,omitempty"`
+	SSL                 bool     `json:"ssl,omitempty"`
+	WiredTiger          bool     `json:"wired_tiger,omitempty"`
+	Notes               string   `json:"notes,omitempty"`
+	CustomerBillingCode string   `json:"customer_billing_code,omitempty"`
 }
 
 //VersionTransition a struct wrapper for version transition information

--- a/tags.go
+++ b/tags.go
@@ -1,0 +1,97 @@
+// Copyright 2017 Compose, an IBM Company
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package composeapi
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/parnurzeal/gorequest"
+)
+
+type clusterTags struct {
+	ClusterTags clusterTagList `json:"cluster"`
+}
+
+type clusterTagList struct {
+	Tags []string `json:"tags"`
+}
+
+func (c *Client) AddTagsToClusterJSON(clusterID string, tags []string) (string, []error) {
+	return c.updateClusterTagsJSON(clusterID, "POST", tags)
+}
+
+func (c *Client) AddTagsToCluster(clusterID string, tags []string) (*Cluster, []error) {
+	return c.updateClusterTags(clusterID, "POST", tags)
+}
+
+func (c *Client) DeleteTagsFromClusterJSON(clusterID string, tags []string) (string, []error) {
+	return c.updateClusterTagsJSON(clusterID, "DELETE", tags)
+}
+
+func (c *Client) DeleteTagsFromCluster(clusterID string, tags []string) (*Cluster, []error) {
+	return c.updateClusterTags(clusterID, "DELETE", tags)
+}
+
+func (c *Client) ReplaceTagsOnClusterJSON(clusterID string, tags []string) (string, []error) {
+	return c.updateClusterTagsJSON(clusterID, "PATCH", tags)
+}
+
+func (c *Client) ReplaceTagsOnCluster(clusterID string, tags []string) (*Cluster, []error) {
+	return c.updateClusterTags(clusterID, "PATCH", tags)
+}
+
+func (c *Client) updateClusterTagsJSON(clusterID, method string, tags []string) (string, []error) {
+	tagParams := clusterTags{
+		ClusterTags: clusterTagList{
+			Tags: tags,
+		},
+	}
+
+	response, body, errs := gorequest.New().
+		CustomMethod(method, tagsEndpoint(clusterID)).
+		Set("Authorization", "Bearer "+c.apiToken).
+		Set("Content-type", "application/json; charset=utf-8").
+		Send(tagParams).
+		End()
+
+	if response.StatusCode != 200 { // Expect OK on success - assume error on anything else
+		myerrors := Errors{}
+		err := json.Unmarshal([]byte(body), &myerrors)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("Unable to parse error - status code %d - body %s",
+				response.StatusCode, response.Body))
+		} else {
+			errs = append(errs, fmt.Errorf("%v", myerrors.Error))
+		}
+	}
+
+	return body, errs
+}
+
+func (c *Client) updateClusterTags(clusterID, method string, tags []string) (*Cluster, []error) {
+	body, errs := c.updateClusterTagsJSON(clusterID, method, tags)
+	if errs != nil {
+		return nil, errs
+	}
+
+	response := Cluster{}
+	json.Unmarshal([]byte(body), &response)
+	return &response, nil
+}
+
+func tagsEndpoint(clusterID string) string {
+	return fmt.Sprintf("%sclusters/%s/tags", apibase, clusterID)
+}


### PR DESCRIPTION
* Add the new 'provisioning_tags' field to the deploymentParams struct so that new deployments can be created using tags
* Expose the new 'tags' field on the Cluster struct
* Add tags.go with methods for the new POST, PATCH and DELETE api calls on the `/clusters/:cluster_id/tags` endpoint

I tested the API methods using [this gist](https://gist.github.com/benjdewan/ddb38a4bd85235e8efcc8a36eb3f3f0c) which adds tags, makes a deployment using tags, changes tags, and then deletes them.