### PR TITLE
Return a full deployment struct from GetDeploymentByName()

### DIFF
--- a/deployment.go
+++ b/deployment.go
@@ -209,7 +209,7 @@ func (c *Client) GetDeploymentByName(deploymentName string) (*Deployment, []erro
 
 	for _, deployment := range *deployments {
 		if deployment.Name == deploymentName {
-			return &deployment, nil
+			return c.GetDeployment(deployment.ID)
 		}
 	}
 


### PR DESCRIPTION
The Deployment structs returned by GetDeployments() include less information than those from GetDeployment(), so the usability of GetDeploymentByName() was inherently less useful than GetDeployment().