### PR TITLE
Retry HTTP Requests when appropriate

### DIFF
--- a/composeapi.go
+++ b/composeapi.go
@@ -23,6 +23,8 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"net/http"
+	"time"
 
 	"github.com/parnurzeal/gorequest"
 )
@@ -33,6 +35,15 @@ const (
 
 // Client is a structure that holds session information for the API
 type Client struct {
+	// The number of times to retry a failing request if the status code is
+	// retryable (e.g. for HTTP 429 or 500)
+	Retries int
+	// The interval to wait between retries. gorequest does not yet support
+	// exponential back-off on retries
+	RetryInterval time.Duration
+	// RetryStatusCodes is the list of status codes to retry for
+	RetryStatusCodes []int
+
 	apiToken      string
 	logger        *log.Logger
 	enableLogging bool
@@ -41,8 +52,17 @@ type Client struct {
 // NewClient returns a Client for further interaction with the API
 func NewClient(apiToken string) (*Client, error) {
 	return &Client{
-		apiToken: apiToken,
-		logger:   log.New(ioutil.Discard, "", 0),
+		apiToken:      apiToken,
+		logger:        log.New(ioutil.Discard, "", 0),
+		Retries:       5,
+		RetryInterval: 3 * time.Second,
+		RetryStatusCodes: []int{
+			http.StatusRequestTimeout,
+			http.StatusTooManyRequests,
+			http.StatusBadGateway,
+			http.StatusServiceUnavailable,
+			http.StatusGatewayTimeout,
+		},
 	}, nil
 }
 
@@ -60,7 +80,8 @@ func (c *Client) newRequest(method, targetURL string) *gorequest.SuperAgent {
 		Set("Authorization", "Bearer "+c.apiToken).
 		Set("Content-type", "application/json; charset=utf-8").
 		SetLogger(c.logger).
-		SetDebug(c.enableLogging)
+		SetDebug(c.enableLogging).
+		Retry(c.Retries, c.RetryInterval, c.RetryStatusCodes...)
 }
 
 // Link structure for JSON+HAL links


### PR DESCRIPTION
Provide values on the Client struct for package users to tweak the retry status codes, retry attempt count, and sleep time, but also use set some sensible defaults.

---

The [existing API documentation](https://apidocs.compose.com/v1.0/reference) does not include any information on what error response codes can be thrown, so my default list is a guess of what errors the API may return that can are not inherently fatal. Hopefully someone can point me at more documentation/source code on retryable errors thrown by the Compose API, or provide some review feedback to clean that up.

Thanks!