### PR TITLE
Expose the gorequest logging interface to gocomposeapi consumers.

### DIFF
--- a/backups.go
+++ b/backups.go
@@ -17,8 +17,6 @@ package composeapi
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/parnurzeal/gorequest"
 )
 
 // Backup structure
@@ -60,9 +58,7 @@ func (c *Client) GetBackupsForDeployment(deploymentid string) (*[]Backup, []erro
 
 //StartBackupForDeploymentJSON starts backup and returns JSON response
 func (c *Client) StartBackupForDeploymentJSON(deploymentid string) (string, []error) {
-	response, body, errs := gorequest.New().Post(apibase+"deployments/"+deploymentid+"/backups").
-		Set("Authorization", "Bearer "+c.apiToken).
-		Set("Content-type", "application/json; charset=utf-8").
+	response, body, errs := c.newRequest("POST", apibase+"deployments/"+deploymentid+"/backups").
 		End()
 
 	if response.StatusCode != 202 { // Expect Accepted on success - assume error on anything else
@@ -148,9 +144,7 @@ func (c *Client) RestoreBackupJSON(params RestoreBackupParams) (string, []error)
 		},
 	}
 
-	response, body, errs := gorequest.New().Post(apibase+"deployments/"+params.DeploymentID+"/backups/"+params.BackupID+"/restore").
-		Set("Authorization", "Bearer "+c.apiToken).
-		Set("Content-type", "application/json; charset=utf-8").
+	response, body, errs := c.newRequest("POST", apibase+"deployments/"+params.DeploymentID+"/backups/"+params.BackupID+"/restore").
 		Send(backupparams).
 		End()
 

--- a/composeapi.go
+++ b/composeapi.go
@@ -19,12 +19,12 @@ package composeapi
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"log"
 
 	"github.com/parnurzeal/gorequest"
 )
-
-var ()
 
 const (
 	apibase = "https://api.compose.io/2016-07/"
@@ -32,14 +32,34 @@ const (
 
 // Client is a structure that holds session information for the API
 type Client struct {
-	apiToken string
+	apiToken      string
+	logger        *log.Logger
+	enableLogging bool
 }
 
 // NewClient returns a Client for further interaction with the API
 func NewClient(apiToken string) (*Client, error) {
 	return &Client{
 		apiToken: apiToken,
+		logger:   log.New(ioutil.Discard, "", 0),
 	}, nil
+}
+
+// SetLogger can enable or disable http logging to and from the Compose
+// API endpoint using the provided io.Writer for the provided client.
+func (c *Client) SetLogger(enableLogging bool, logger io.Writer) *Client {
+	c.logger = log.New(logger, "[composeapi]", log.LstdFlags)
+	c.enableLogging = enableLogging
+	return c
+}
+
+func (c *Client) newRequest(method, targetURL string) *gorequest.SuperAgent {
+	return gorequest.New().
+		CustomMethod(method, targetURL).
+		Set("Authorization", "Bearer "+c.apiToken).
+		Set("Content-type", "application/json; charset=utf-8").
+		SetLogger(c.logger).
+		SetDebug(c.enableLogging)
 }
 
 // Link structure for JSON+HAL links
@@ -73,10 +93,8 @@ func (c *Client) SetAPIToken(newtoken string) {
 
 //GetJSON Gets JSON string of content at an endpoint
 func (c *Client) getJSON(endpoint string) (string, []error) {
-	response, body, errs := gorequest.New().Get(apibase+endpoint).
-		Set("Authorization", "Bearer "+c.apiToken).
-		Set("Content-type", "json").
-		End()
+	response, body, errs := c.newRequest("GET", apibase+endpoint).End()
+
 	if response.StatusCode != 200 {
 		myerrors := Errors{}
 		err := json.Unmarshal([]byte(body), &myerrors)

--- a/database.go
+++ b/database.go
@@ -17,8 +17,6 @@ package composeapi
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/parnurzeal/gorequest"
 )
 
 //Version structure
@@ -54,10 +52,7 @@ func (c *Client) UpdateVersionJSON(deploymentID string, version string) (string,
 		Deployment: deploymentVersion{Version: version},
 	}
 
-	response, body, errs := gorequest.New().
-		Patch(apibase+"deployments/"+deploymentID+"/versions").
-		Set("Authorization", "Bearer "+c.apiToken).
-		Set("Content-type", "application/json; charset=utf-8").
+	response, body, errs := c.newRequest("PATCH", apibase+"deployments/"+deploymentID+"/versions").
 		Send(patchParams).
 		End()
 

--- a/deployment.go
+++ b/deployment.go
@@ -18,8 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
-
-	"github.com/parnurzeal/gorequest"
 )
 
 // Deployment structure
@@ -128,9 +126,7 @@ type deploymentVersion struct {
 func (c *Client) CreateDeploymentJSON(params DeploymentParams) (string, []error) {
 	deploymentparams := CreateDeploymentParams{Deployment: params}
 
-	response, body, errs := gorequest.New().Post(apibase+"deployments").
-		Set("Authorization", "Bearer "+c.apiToken).
-		Set("Content-type", "application/json; charset=utf-8").
+	response, body, errs := c.newRequest("POST", apibase+"deployments").
 		Send(deploymentparams).
 		End()
 
@@ -220,9 +216,7 @@ func (c *Client) GetDeploymentByName(deploymentName string) (*Deployment, []erro
 //DeprovisionDeploymentJSON performs the call
 func (c *Client) DeprovisionDeploymentJSON(deploymentID string) (string, []error) {
 
-	response, body, errs := gorequest.New().Delete(apibase+"deployments/"+deploymentID).
-		Set("Authorization", "Bearer "+c.apiToken).
-		Set("Content-type", "application/json; charset=utf-8").
+	response, body, errs := c.newRequest("DELETE", apibase+"deployments/"+deploymentID).
 		End()
 
 	if response.StatusCode != 202 { // Expect Accepted on success - assume error on anything else
@@ -264,9 +258,7 @@ func (c *Client) PatchDeploymentJSON(params PatchDeploymentParams) (string, []er
 			Notes:               params.Notes,
 		}}
 
-	response, body, errs := gorequest.New().Patch(apibase+"deployments/"+patchParams.DeploymentID).
-		Set("Authorization", "Bearer "+c.apiToken).
-		Set("Content-type", "application/json; charset=utf-8").
+	response, body, errs := c.newRequest("PATCH", apibase+"deployments/"+patchParams.DeploymentID).
 		Send(patchParams).
 		End()
 

--- a/scalings.go
+++ b/scalings.go
@@ -17,8 +17,6 @@ package composeapi
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/parnurzeal/gorequest"
 )
 
 // Scalings represents the used, allocated, starting and minimum unit scale
@@ -72,9 +70,7 @@ func (c *Client) SetScalingsJSON(params ScalingsParams) (string, []error) {
 		Deployment: scalingSettingParams{Units: params.Units},
 	}
 
-	response, body, errs := gorequest.New().Post(apibase+"deployments/"+params.DeploymentID+"/scalings").
-		Set("Authorization", "Bearer "+c.apiToken).
-		Set("Content-type", "application/json; charset=utf-8").
+	response, body, errs := c.newRequest("POST", apibase+"deployments/"+params.DeploymentID+"/scalings").
 		Send(scalingsparams).
 		End()
 

--- a/tags.go
+++ b/tags.go
@@ -17,8 +17,6 @@ package composeapi
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/parnurzeal/gorequest"
 )
 
 type clusterTags struct {
@@ -54,17 +52,9 @@ func (c *Client) ReplaceTagsOnCluster(clusterID string, tags []string) (*Cluster
 }
 
 func (c *Client) updateClusterTagsJSON(clusterID, method string, tags []string) (string, []error) {
-	tagParams := clusterTags{
-		ClusterTags: clusterTagList{
-			Tags: tags,
-		},
-	}
 
-	response, body, errs := gorequest.New().
-		CustomMethod(method, tagsEndpoint(clusterID)).
-		Set("Authorization", "Bearer "+c.apiToken).
-		Set("Content-type", "application/json; charset=utf-8").
-		Send(tagParams).
+	response, body, errs := c.newRequest(method, tagsEndpoint(clusterID)).
+		Send(clusterTags{ClusterTags: clusterTagList{Tags: tags}}).
 		End()
 
 	if response.StatusCode != 200 { // Expect OK on success - assume error on anything else

--- a/team_roles.go
+++ b/team_roles.go
@@ -17,8 +17,6 @@ package composeapi
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/parnurzeal/gorequest"
 )
 
 // TeamRole the name of the role and list of teams with that role for a
@@ -46,9 +44,7 @@ type teamRolesResponse struct {
 
 // CreateTeamRoleJSON performs the raw call to add a new team role
 func (c *Client) CreateTeamRoleJSON(deploymentID string, params TeamRoleParams) (string, []error) {
-	response, body, errs := gorequest.New().Post(teamRolesEndpoint(deploymentID)).
-		Set("Authorization", "Bearer "+c.apiToken).
-		Set("Content-type", "application/json; charset=utf-8").
+	response, body, errs := c.newRequest("POST", teamRolesEndpoint(deploymentID)).
 		Send(updateTeamRole{TeamRole: params}).
 		End()
 
@@ -99,9 +95,7 @@ func (c *Client) GetTeamRoles(deploymentID string) (*[]TeamRole, []error) {
 
 // DeleteTeamRoleJSON is the raw call to remove a team_role
 func (c *Client) DeleteTeamRoleJSON(deploymentID string, params TeamRoleParams) []error {
-	response, body, errs := gorequest.New().Delete(teamRolesEndpoint(deploymentID)).
-		Set("Authorization", "Bearer "+c.apiToken).
-		Set("Content-type", "application/json; charset=utf-8").
+	response, body, errs := c.newRequest("DELETE", teamRolesEndpoint(deploymentID)).
 		Send(updateTeamRole{TeamRole: params}).
 		End()
 

--- a/teams.go
+++ b/teams.go
@@ -17,8 +17,6 @@ package composeapi
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/parnurzeal/gorequest"
 )
 
 // Team structure
@@ -55,9 +53,7 @@ type TeamParams struct {
 func (c *Client) CreateTeamJSON(params TeamParams) (string, []error) {
 	teamParams := createTeamParams{Team: params}
 
-	response, body, errs := gorequest.New().Post(apibase+"teams").
-		Set("Authorization", "Bearer "+c.apiToken).
-		Set("Content-type", "application/json; charset=utf-8").
+	response, body, errs := c.newRequest("POST", apibase+"teams").
 		Send(teamParams).
 		End()
 
@@ -145,9 +141,7 @@ func (c *Client) GetTeamByName(teamName string) (*Team, []error) {
 
 // DeleteTeamJSON performs that call
 func (c *Client) DeleteTeamJSON(teamID string) (string, []error) {
-	response, body, errs := gorequest.New().Delete(apibase+"teams/"+teamID).
-		Set("Authorization", "Bearer "+c.apiToken).
-		Set("Content-type", "application/json; charset=utf-8").
+	response, body, errs := c.newRequest("DELETE", apibase+"teams/"+teamID).
 		End()
 
 	if response.StatusCode != 200 { // Expect OK on success - assume error on anything else
@@ -181,9 +175,7 @@ func (c *Client) DeleteTeam(teamID string) (*Team, []error) {
 func (c *Client) PatchTeamJSON(teamID, teamName string) (string, []error) {
 	patchParams := patchTeamParams{Team: TeamParams{Name: teamName}}
 
-	response, body, errs := gorequest.New().Patch(apibase+"teams/"+teamID).
-		Set("Authorization", "Bearer "+c.apiToken).
-		Set("Content-type", "application/json; charset=utf-8").
+	response, body, errs := c.newRequest("PATCH", apibase+"teams/"+teamID).
 		Send(patchParams).
 		End()
 
@@ -218,10 +210,7 @@ func (c *Client) PatchTeam(teamID, teamName string) (*Team, []error) {
 func (c *Client) PutTeamUsersJSON(teamID string, userIDs []string) (string, []error) {
 	putUsers := putTeamUsersParams{UserIDs: userIDs}
 
-	response, body, errs := gorequest.New().
-		Put(apibase+"teams/"+teamID+"/users").
-		Set("Authorization", "Bearer "+c.apiToken).
-		Set("Content-type", "application/json; charset=utf-8").
+	response, body, errs := c.newRequest("PUT", apibase+"teams/"+teamID+"/users").
 		Send(putUsers).
 		End()
 


### PR DESCRIPTION
Without this change it was possible to enable debugging mode on gorequest, but not to redirect it from os.Stderr to another destination.

Additionally, because the boilerplate for every gorequest to enable this new logging access is so high there is now a `client.newRequest()` method to hide a great deal of it.