### PR TITLE
Add support for the redis 'cache_mode' option

### DIFF
--- a/deployment.go
+++ b/deployment.go
@@ -97,6 +97,7 @@ type DeploymentParams struct {
 	Units               int      `json:"units,omitempty"`
 	SSL                 bool     `json:"ssl,omitempty"`
 	WiredTiger          bool     `json:"wired_tiger,omitempty"`
+	CacheMode           bool     `json:"cache_mode,omitempty"`
 	Notes               string   `json:"notes,omitempty"`
 	CustomerBillingCode string   `json:"customer_billing_code,omitempty"`
 }


### PR DESCRIPTION
It's an option in the Compose API docs that
gocomposeapi did not yet support