### PR TITLE
Add support for more /accounts API commands

### DIFF
--- a/user.go
+++ b/user.go
@@ -24,6 +24,13 @@ type User struct {
 	Name string `json:"name"`
 }
 
+// UserParams structure
+type UserParams struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+	Phone string `json:"phone"`
+}
+
 //GetUserJSON returns user JSON string
 func (c *Client) GetUserJSON() (string, []error) {
 	return c.getJSON("user")


### PR DESCRIPTION
Newly supported API methods:
* PATCH /2016-07/accounts/:account_id
* POST /2016-07/accounts/:account_id/users
* DELETE /2016-07/accounts/:account_id/users/:user_id

This is my testing script: https://gist.github.com/benjdewan/c44c755fa941e33b0ad7010f4bcd5e89

NOTES:
 * I found a bug in the Compose API documentation. A successful [`POST /2016-07/accounts/:account_id/users`](https://apidocs.compose.com/v1.0/reference#2016-07-post-accounts-users) returns a `201 Created` message (which is correct), not a `200 OK` (which is what the docs state)
* Every time I have tried to do a `PATCH` API request using CURL, the API Docs interface or this library it returns an `500 Internal Server Error`. Is that because I'm using the example Stripe ID, and not generating my own?