### PR TITLE
Add cache mode parameter for deployments

### DIFF
--- a/deployment.go
+++ b/deployment.go
@@ -96,6 +96,7 @@ type DeploymentParams struct {
 	Version             string   `json:"version,omitempty"`
 	Units               int      `json:"units,omitempty"`
 	SSL                 bool     `json:"ssl,omitempty"`
+	CacheMode           bool     `json:"cache_mode,omitempty"`
 	WiredTiger          bool     `json:"wired_tiger,omitempty"`
 	Notes               string   `json:"notes,omitempty"`
 	CustomerBillingCode string   `json:"customer_billing_code,omitempty"`


### PR DESCRIPTION
A pull request for this change already exists (https://github.com/compose/gocomposeapi/pull/22), but this one has a more detailed commit message :)

The `deployment.cache_mode` parameter has now been included in the API
documentation[1]. It controls whether to optimize the deployment to be
used as a cache (Redis only).

[1] https://apidocs.compose.com/v1.0/reference#2016-07-post-deployments