### PR TITLE
Upgrade the gorequest dependency to 0.2.15

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -31,6 +31,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b7c9365cb165019c04c544d0a164b745d81bccba70ce7bf27a85d136989657a2"
+  inputs-digest = "429716c7f4987076a14c793a0926565e1cca8c9dbcf8d75cc79a516be6bc5c3a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,4 +23,4 @@
 
 [[constraint]]
   name = "github.com/parnurzeal/gorequest"
-  version = "0.2.14"
+  version = "0.2.15"

--- a/composeapi.go
+++ b/composeapi.go
@@ -81,6 +81,7 @@ func (c *Client) newRequest(method, targetURL string) *gorequest.SuperAgent {
 		Set("Content-type", "application/json; charset=utf-8").
 		SetLogger(c.logger).
 		SetDebug(c.enableLogging).
+		SetCurlCommand(c.enableLogging).
 		Retry(c.Retries, c.RetryInterval, c.RetryStatusCodes...)
 }
 


### PR DESCRIPTION
0.2.15 has support for improved debugging by printing runnable curl commands for every request made.

---
Example: `client.GetAccount()`
Before:
```text
[http] 2017/10/09 07:50:41 HTTP Request: GET /2016-07/accounts HTTP/1.1
Host: api.compose.io
Authorization: Bearer {{.OMITTING_MY_TOKEN}}
Content-Type: application/json; charset=utf-8

{"_embedded":{"accounts":[{"id":"{{.OMITTED_ACCOUNT_ID}}","slug":"client-library-testing","name":"client-library-testing"}]}}
```
After:
```text
[http] 2017/10/09 07:50:41 HTTP Request: GET /2016-07/accounts HTTP/1.1
Host: api.compose.io
Authorization: Bearer {{.OMITTING_MY_TOKEN}}
Content-Type: application/json; charset=utf-8

[curl] 2017/10/09 07:50:41 CURL command line: curl -X 'GET' -d '' -H 'Authorization: Bearer {{.OMITTING_MY_TOKEN}}' -H 'Content-Type: application/json; charset=utf-8' 'https://api.compose.io/2016-07/accounts'
[curl] 2017/10/09 07:50:41 HTTP Response: HTTP/1.1 200 OK
Connection: close
Cache-Control: max-age=0, private, must-revalidate
Content-Type: application/json; charset=utf-8
Date: Mon, 09 Oct 2017 11:50:41 GMT
Etag: W/"{{.OMITTED_ETAG}}"
Strict-Transport-Security: max-age=31536000
Vary: Accept-Encoding, Origin
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Rack-Cors: miss; no-origin
X-Request-Id: {{.OMITTED_REQUEST_ID}}
X-Runtime: 0.017632
X-Xss-Protection: 1; mode=block

{"_embedded":{"accounts":[{"id":"{{.OMITTED_ACCOUNT_ID}}","slug":"client-library-testing","name":"client-library-testing"}]}}
```