### PR TITLE
Add creation time and boolean flags to `Backup`

### DIFF
--- a/backups.go
+++ b/backups.go
@@ -16,16 +16,20 @@ package composeapi
 
 import (
 	"encoding/json"
+	"time"
 )
 
 // Backup structure
 type Backup struct {
-	ID           string `json:"id"`
-	Deploymentid string `json:"deployment_id"`
-	Name         string `json:"name"`
-	Type         string `json:"type"`
-	Status       string `json:"status"`
-	DownloadLink string `json:"download_link"`
+	ID             string    `json:"id"`
+	Deploymentid   string    `json:"deployment_id"`
+	Name           string    `json:"name"`
+	Type           string    `json:"type"`
+	Status         string    `json:"status"`
+	IsDownloadable bool      `json:"is_downloadable"`
+	IsRestorable   bool      `json:"is_restorable"`
+	CreatedAt      time.Time `json:"created_at"`
+	DownloadLink   string    `json:"download_link"`
 }
 
 // backupsResponse is used to represent and remove the JSON+HAL Embedded wrapper


### PR DESCRIPTION
Hi Compose! These fields are listed in the latest API JSON examples [1] and appear in API responses, but were not being deserialised onto the struct. We're doing some backup automation and so needed to use those fields.

[1] https://apidocs.compose.com/v1.0/reference#2016-07-get-deployments-backups