### PR TITLE
Gorequest may return nil values for responses

### DIFF
--- a/account.go
+++ b/account.go
@@ -95,6 +95,10 @@ func (c *Client) CreateAccountUserJSON(accountID string, params UserParams) (str
 		Send(params).
 		End()
 
+	if response == nil {
+		return internalError(errs)
+	}
+
 	if response.StatusCode != 201 { // Expect Created on success
 		errs = ProcessErrors(response.StatusCode, body)
 	}
@@ -119,6 +123,10 @@ func (c *Client) DeleteAccountUserJSON(accountID, userID string) (string, []erro
 	response, body, errs := c.newRequest("DELETE",
 		apibase+"accounts/"+accountID+"/users/"+userID).
 		End()
+
+	if response == nil {
+		return internalError(errs)
+	}
 
 	if response.StatusCode != 200 { // Expect OK on success
 		errs = ProcessErrors(response.StatusCode, body)

--- a/audit_events.go
+++ b/audit_events.go
@@ -57,6 +57,10 @@ func (c *Client) GetAuditEventsJSON(params AuditEventsParams) (string, []error) 
 		Query(params).
 		End()
 
+	if response == nil {
+		return internalError(errs)
+	}
+
 	if response.StatusCode != 200 { // Expect Accepted on success - assume error on anything else
 		myerrors := Errors{}
 		err := json.Unmarshal([]byte(body), &myerrors)
@@ -85,6 +89,10 @@ func (c *Client) GetAuditEvents(params AuditEventsParams) (*[]AuditEvent, []erro
 func (c *Client) GetAuditEventJSON(id string) (string, []error) {
 	response, body, errs := c.newRequest("GET", apibase+"/audit_events/"+id).
 		End()
+
+	if response == nil {
+		return internalError(errs)
+	}
 
 	if response.StatusCode != 200 { // Expect Accepted on success - assume error on anything else
 		errs = ProcessErrors(response.StatusCode, body)

--- a/backups.go
+++ b/backups.go
@@ -64,6 +64,10 @@ func (c *Client) StartBackupForDeploymentJSON(deploymentid string) (string, []er
 	response, body, errs := c.newRequest("POST", apibase+"deployments/"+deploymentid+"/backups").
 		End()
 
+	if response == nil {
+		return internalError(errs)
+	}
+
 	if response.StatusCode != 202 { // Expect Accepted on success - assume error on anything else
 		errs = ProcessErrors(response.StatusCode, body)
 	}
@@ -144,6 +148,10 @@ func (c *Client) RestoreBackupJSON(params RestoreBackupParams) (string, []error)
 	response, body, errs := c.newRequest("POST", apibase+"deployments/"+params.DeploymentID+"/backups/"+params.BackupID+"/restore").
 		Send(backupparams).
 		End()
+
+	if response == nil {
+		return internalError(errs)
+	}
 
 	if response.StatusCode != 202 { // Expect Accepted on success - assume error on anything else
 		errs = ProcessErrors(response.StatusCode, body)

--- a/database.go
+++ b/database.go
@@ -56,6 +56,10 @@ func (c *Client) UpdateVersionJSON(deploymentID string, version string) (string,
 		Send(patchParams).
 		End()
 
+	if response == nil {
+		return internalError(errs)
+	}
+
 	if response.StatusCode != 200 { // Expect OK on success - assume error on anything else
 		errs = ProcessErrors(response.StatusCode, body)
 	}

--- a/deployment.go
+++ b/deployment.go
@@ -134,6 +134,10 @@ func (c *Client) CreateDeploymentJSON(params DeploymentParams) (string, []error)
 		Send(deploymentparams).
 		End()
 
+	if response == nil {
+		return internalError(errs)
+	}
+
 	if response.StatusCode != 202 { // Expect Accepted on success - assume error on anything else
 		myerrors := Errors{}
 		err := json.Unmarshal([]byte(body), &myerrors)
@@ -223,6 +227,10 @@ func (c *Client) DeprovisionDeploymentJSON(deploymentID string) (string, []error
 	response, body, errs := c.newRequest("DELETE", apibase+"deployments/"+deploymentID).
 		End()
 
+	if response == nil {
+		return internalError(errs)
+	}
+
 	if response.StatusCode != 202 { // Expect Accepted on success - assume error on anything else
 		errs = ProcessErrors(response.StatusCode, body)
 	}
@@ -259,6 +267,10 @@ func (c *Client) PatchDeploymentJSON(params PatchDeploymentParams) (string, []er
 	response, body, errs := c.newRequest("PATCH", apibase+"deployments/"+patchParams.DeploymentID).
 		Send(patchParams).
 		End()
+
+	if response == nil {
+		return internalError(errs)
+	}
 
 	if response.StatusCode != 200 { // Expect Accepted on success - assume error on anything else
 		errs = ProcessErrors(response.StatusCode, body)

--- a/scalings.go
+++ b/scalings.go
@@ -73,6 +73,10 @@ func (c *Client) SetScalingsJSON(params ScalingsParams) (string, []error) {
 		Send(scalingsparams).
 		End()
 
+	if response == nil {
+		return internalError(errs)
+	}
+
 	if response.StatusCode != 200 { // Expect Accepted on success - assume error on anything else
 		errs = ProcessErrors(response.StatusCode, body)
 	}

--- a/tags.go
+++ b/tags.go
@@ -63,6 +63,10 @@ func (c *Client) updateClusterTagsJSON(clusterID, method string, tags []string) 
 		Send(clusterTags{ClusterTags: clusterTagList{Tags: tags}}).
 		End()
 
+	if response == nil {
+		return internalError(errs)
+	}
+
 	if response.StatusCode != 200 { // Expect OK on success - assume error on anything else
 		errs = ProcessErrors(response.StatusCode, body)
 	}

--- a/team_roles.go
+++ b/team_roles.go
@@ -16,6 +16,7 @@ package composeapi
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -47,6 +48,10 @@ func (c *Client) CreateTeamRoleJSON(deploymentID string, params TeamRoleParams) 
 	response, body, errs := c.newRequest("POST", teamRolesEndpoint(deploymentID)).
 		Send(updateTeamRole{TeamRole: params}).
 		End()
+
+	if response == nil {
+		return internalError(errs)
+	}
 
 	if response.StatusCode != 201 {
 		myErrors := Errors{}
@@ -98,6 +103,13 @@ func (c *Client) DeleteTeamRoleJSON(deploymentID string, params TeamRoleParams) 
 	response, body, errs := c.newRequest("DELETE", teamRolesEndpoint(deploymentID)).
 		Send(updateTeamRole{TeamRole: params}).
 		End()
+
+	if response == nil {
+		if len(errs) > 0 {
+			return errs
+		}
+		return []error{errors.New(gorequestInternalFailure)}
+	}
 
 	if response.StatusCode != 204 { // No response body is returned on success
 		errs = ProcessErrors(response.StatusCode, body)

--- a/teams.go
+++ b/teams.go
@@ -57,6 +57,10 @@ func (c *Client) CreateTeamJSON(params TeamParams) (string, []error) {
 		Send(teamParams).
 		End()
 
+	if response == nil {
+		return internalError(errs)
+	}
+
 	if response.StatusCode != 201 { // Expect Created on success - assume error on anything else
 		errs = ProcessErrors(response.StatusCode, body)
 	}
@@ -137,6 +141,10 @@ func (c *Client) DeleteTeamJSON(teamID string) (string, []error) {
 	response, body, errs := c.newRequest("DELETE", apibase+"teams/"+teamID).
 		End()
 
+	if response == nil {
+		return internalError(errs)
+	}
+
 	if response.StatusCode != 200 { // Expect OK on success - assume error on anything else
 		errs = ProcessErrors(response.StatusCode, body)
 	}
@@ -165,6 +173,10 @@ func (c *Client) PatchTeamJSON(teamID, teamName string) (string, []error) {
 		Send(patchParams).
 		End()
 
+	if response == nil {
+		return internalError(errs)
+	}
+
 	if response.StatusCode != 200 { // Expect OK on success - assume error on anything else
 		errs = ProcessErrors(response.StatusCode, body)
 	}
@@ -192,6 +204,10 @@ func (c *Client) PutTeamUsersJSON(teamID string, userIDs []string) (string, []er
 	response, body, errs := c.newRequest("PUT", apibase+"teams/"+teamID+"/users").
 		Send(putUsers).
 		End()
+
+	if response == nil {
+		return internalError(errs)
+	}
 
 	if response.StatusCode != 200 { // Expect OK on success - assume error on anything else
 		errs = ProcessErrors(response.StatusCode, body)

--- a/whitelist.go
+++ b/whitelist.go
@@ -58,6 +58,10 @@ func (c *Client) createDeploymentWhitelistJSON(deploymentID string, params Deplo
 		Send(whitelistParams).
 		End()
 
+	if response == nil {
+		return internalError(errs)
+	}
+
 	if response.StatusCode != 202 {
 		myerrors := Errors{}
 		err := json.Unmarshal([]byte(body), &myerrors)


### PR DESCRIPTION
If an HTTP connection returns unsuccessfully, gorequest will return nil for the response object, so attempting to view the StatusCode will trigger a SIGSEGV panic.

It is therefore only safe to make that check after ensuring that the response is non-nil

I have a code snippet that I used to track down the root of the panic, as well as verify that this fix works: https://gist.github.com/benjdewan/4941195e771a42f076383c95aaf796d8

When we hit this corner case the errors `gorequest` may return will never be properly processed by `ProcessErrors` because they are not returned by the compose API, but from within the gorequest library or one of its dependencies which is why the new code does not invoke that method.